### PR TITLE
Add async Crawlee email crawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Crawlee Email Scraper
+
+This repository includes an asynchronous email scraping tool powered by the [Crawlee](https://crawlee.dev/) Python library.
+
+## Installation
+
+```bash
+# Create and activate a virtual environment (optional)
+python -m venv venv
+source venv/bin/activate
+
+# Install dependencies
+pip install -e crawlee-python
+pip install -r classicalemailscraper/requirements.txt
+pip install playwright
+playwright install --with-deps chromium
+```
+
+## Usage
+
+Run the crawler with one or more seed URLs:
+
+```bash
+python -m src.crawler2.main <start_url1> [<start_url2> ...] --max-pages 10
+```
+
+Results are stored in local Crawlee datasets under `storage/datasets/`.
+
+## Test Report Example
+
+To reproduce the test crawl used in development:
+
+```bash
+python -m src.crawler2.main \
+  http://www.mapsoft.com \
+  http://www.puzzle.ch \
+  http://www.obsmedical.com \
+  http://www.mediamelon.com \
+  http://www.crosig.hr \
+  --max-pages 10
+```
+
+After the crawl completes, a summary of pages scraped and deduplicated emails per domain will be printed.

--- a/src/crawler2/__main__.py
+++ b/src/crawler2/__main__.py
@@ -1,0 +1,14 @@
+from .main import run
+
+if __name__ == "__main__":
+    import argparse
+    import asyncio
+    parser = argparse.ArgumentParser(description="Async email scraper using Crawlee")
+    parser.add_argument("start_urls", nargs="+", help="Seed URLs to crawl")
+    parser.add_argument("--max-pages", type=int, default=50, dest="max_pages", help="Maximum pages per domain")
+    parser.add_argument("--concurrency", type=int, default=5, help="Max concurrent pages")
+    parser.add_argument("--proxy", nargs="*", dest="proxy_urls", help="Proxy URLs to rotate")
+    args = parser.parse_args()
+    summaries = asyncio.run(run(args.start_urls, args.max_pages, args.concurrency, args.proxy_urls))
+    from pprint import pprint
+    pprint(summaries)

--- a/src/crawler2/crawler.py
+++ b/src/crawler2/crawler.py
@@ -1,0 +1,60 @@
+from typing import Iterable, List, Dict
+from urllib.parse import urlparse
+
+from crawlee import ConcurrencySettings
+from crawlee.crawlers import PlaywrightCrawler, PlaywrightCrawlingContext
+from crawlee.proxy_configuration import ProxyConfiguration
+from crawlee.storages import Dataset
+
+from .email_extractor import extract_emails_from_html
+
+async def crawl_domain(start_url: str, *, max_pages: int = 50, concurrency: int = 5,
+                       proxy_urls: Iterable[str] | None = None) -> Dict:
+    """Crawl a single domain starting from ``start_url``.
+
+    Returns summary statistics with pages scraped and deduplicated emails.
+    """
+    domain = urlparse(start_url).netloc
+    dataset = await Dataset.open(name=f"emails-{domain}")
+    await dataset.drop()
+
+    proxy_config = ProxyConfiguration(proxy_urls=list(proxy_urls)) if proxy_urls else None
+
+    crawler = PlaywrightCrawler(
+        max_requests_per_crawl=max_pages,
+        concurrency_settings=ConcurrencySettings(max_concurrency=concurrency),
+        proxy_configuration=proxy_config,
+        use_session_pool=True,
+        respect_robots_txt_file=True,
+    )
+
+    @crawler.router.default_handler
+    async def handle_page(context: PlaywrightCrawlingContext) -> None:
+        await context.page.wait_for_load_state("networkidle")
+        html = await context.page.content()
+        emails = extract_emails_from_html(html)
+        for email in emails:
+            await dataset.push_data({"url": context.request.url, "email": email})
+        await context.enqueue_links()
+
+    stats = await crawler.run([start_url])
+
+    # Gather dataset results
+    items: List[Dict] = []
+    offset = 0
+    while True:
+        page = await dataset.get_data(limit=1000, offset=offset)
+        items.extend(page.items)
+        if page.total <= offset + page.count:
+            break
+        offset += page.count
+
+    unique_emails = sorted({it["email"] for it in items})
+    page_urls = {it["url"] for it in items}
+
+    return {
+        "domain": domain,
+        "pages_scraped": stats.requests_finished,
+        "deduped_emails": unique_emails,
+        "urls_visited": list(page_urls),
+    }

--- a/src/crawler2/email_extractor.py
+++ b/src/crawler2/email_extractor.py
@@ -1,0 +1,7 @@
+import re
+
+EMAIL_REGEX = r'[a-zA-Z0-9.\-+_]+@[a-zA-Z0-9.\-+_]+\.[a-zA-Z]+'
+
+def extract_emails_from_html(html: str) -> set[str]:
+    """Return a set of emails found within the given HTML string."""
+    return set(re.findall(EMAIL_REGEX, html))

--- a/src/crawler2/main.py
+++ b/src/crawler2/main.py
@@ -1,0 +1,22 @@
+import argparse
+import asyncio
+from pprint import pprint
+
+from .crawler import crawl_domain
+
+async def run(start_urls, max_pages, concurrency, proxy_urls):
+    results = []
+    for url in start_urls:
+        summary = await crawl_domain(url, max_pages=max_pages, concurrency=concurrency, proxy_urls=proxy_urls)
+        results.append(summary)
+    return results
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Async email scraper using Crawlee")
+    parser.add_argument("start_urls", nargs="+", help="Seed URLs to crawl")
+    parser.add_argument("--max-pages", type=int, default=50, dest="max_pages", help="Maximum pages per domain")
+    parser.add_argument("--concurrency", type=int, default=5, help="Max concurrent pages")
+    parser.add_argument("--proxy", nargs="*", dest="proxy_urls", help="Proxy URLs to rotate")
+    args = parser.parse_args()
+    summaries = asyncio.run(run(args.start_urls, args.max_pages, args.concurrency, args.proxy_urls))
+    pprint(summaries)


### PR DESCRIPTION
## Summary
- add crawler2 module with async Crawlee-based crawler
- expose CLI entry points
- document setup and usage

## Testing
- `python -m src.crawler2.main http://www.mapsoft.com --max-pages 1 --concurrency 1` *(fails: All connection attempts failed)*

------
https://chatgpt.com/codex/tasks/task_e_6857eb9a400c83308f21a1135fc05f1a