### PR TITLE
Fix dataset recreation after dropping

### DIFF
--- a/src/crawler2/crawler.py
+++ b/src/crawler2/crawler.py
@@ -17,6 +17,7 @@ async def crawl_domain(start_url: str, *, max_pages: int = 50, concurrency: int 
     domain = urlparse(start_url).netloc
     dataset = await Dataset.open(name=f"emails-{domain}")
     await dataset.drop()
+    dataset = await Dataset.open(name=f"emails-{domain}")
 
     proxy_config = ProxyConfiguration(proxy_urls=list(proxy_urls)) if proxy_urls else None
 


### PR DESCRIPTION
## Summary
- ensure dataset is re-opened after drop in crawler

## Testing
- `pytest crawlee-python/tests/unit/storages/test_dataset.py::test_open -vv`
- `pip install -e crawlee-python`
- `pip install playwright`
- `playwright install --with-deps chromium`

------
https://chatgpt.com/codex/tasks/task_e_6858085a40ec8330ba03f7ac9400f4e4