### PR TITLE
Implement async Crawlee email crawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# CrawlFused Email Scrapper
+
+This repository provides tools for collecting email addresses from websites.
+It includes a basic scraper from `classicalemailscraper` and an asynchronous
+crawler built on [Crawlee](https://crawlee.dev/) located in `src/email_crawler3/`.
+
+## Installation
+
+Use a Python 3.11+ environment. Install dependencies from the included
+projects:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e crawlee-python
+pip install -r classicalemailscraper/requirements.txt
+```
+
+## Usage
+
+Run the asynchronous crawler from the repository root:
+
+```bash
+python src/email_crawler3/main.py https://example.com
+```
+
+Optional arguments:
+
+- `--http-only` – use the HTTP crawler instead of Playwright.
+- `--proxy URL` – proxy URL to rotate; can be specified multiple times.
+- `--concurrency N` – maximum concurrent requests (default: 5).
+
+The crawler respects `robots.txt`, manages sessions, rotates proxies when
+provided and extracts emails using the logic from `classicalemailscraper`.

--- a/src/email_crawler3/main.py
+++ b/src/email_crawler3/main.py
@@ -1,0 +1,81 @@
+import argparse
+import asyncio
+from crawlee.crawlers import PlaywrightCrawler, HttpCrawler
+from crawlee import ConcurrencySettings
+from crawlee.proxy_configuration import ProxyConfiguration
+import importlib.util
+import builtins
+from pathlib import Path
+
+# Load extract_emails from classicalemailscraper without running its CLI section
+_scraper_path = Path(__file__).resolve().parents[1] / ".." / "classicalemailscraper" / "email_scraper.py"
+spec = importlib.util.spec_from_file_location("_email_scraper", _scraper_path)
+_module = importlib.util.module_from_spec(spec)
+_orig_input = builtins.input
+builtins.input = lambda *a, **k: (_ for _ in ()).throw(SystemExit)
+try:
+    spec.loader.exec_module(_module)  # type: ignore[arg-type]
+except SystemExit:
+    pass
+finally:
+    builtins.input = _orig_input
+
+extract_emails = _module.extract_emails
+
+
+async def run_crawler(start_urls: list[str], *, use_playwright: bool = True,
+                      proxy_urls: list[str] | None = None, max_concurrency: int = 5) -> set[str]:
+    proxy_config = ProxyConfiguration(proxy_urls=proxy_urls) if proxy_urls else None
+    crawler_cls = PlaywrightCrawler if use_playwright else HttpCrawler
+
+    concurrency = ConcurrencySettings(max_concurrency=max_concurrency)
+    crawler = crawler_cls(
+        proxy_configuration=proxy_config,
+        use_session_pool=True,
+        respect_robots_txt_file=True,
+        concurrency_settings=concurrency,
+    )
+
+    found_emails: set[str] = set()
+
+    @crawler.router.default_handler
+    async def handle_request(context):
+        context.log.info(f"Processing {context.request.url}")
+        if hasattr(context, "page"):
+            body = await context.page.content()
+        else:
+            body = context.http_response.read().decode()
+        found_emails.update(extract_emails(body))
+        await context.enqueue_links()
+
+    await crawler.run(start_urls)
+    return found_emails
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Asynchronous email crawler")
+    parser.add_argument("start_url", help="URL to start crawling from")
+    parser.add_argument("--http-only", action="store_true", help="Use HTTP crawler instead of Playwright")
+    parser.add_argument("--proxy", action="append", help="Proxy URL to use. Can be specified multiple times")
+    parser.add_argument("--concurrency", type=int, default=5, help="Maximum concurrent requests")
+    args = parser.parse_args()
+
+    emails = asyncio.run(
+        run_crawler(
+            [args.start_url],
+            use_playwright=not args.http_only,
+            proxy_urls=args.proxy,
+            max_concurrency=args.concurrency,
+        )
+    )
+
+    if emails:
+        print("Found emails:")
+        for email in sorted(emails):
+            print(email)
+    else:
+        print("No emails found.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a README with installation and usage
- implement `email_crawler3` package with a CLI for an async crawler

## Testing
- `python src/email_crawler3/main.py --help`
- `python src/email_crawler3/main.py https://example.com --http-only --concurrency 1` *(fails: All connection attempts failed)*

------
https://chatgpt.com/codex/tasks/task_e_6858144f7f188330889949fdd4e0040c